### PR TITLE
Post-R1 Bug Fixes

### DIFF
--- a/make-figures.R
+++ b/make-figures.R
@@ -160,7 +160,7 @@ scatter_f = function(species, strat, legend_loc) {
        labels = paste0("", KuskoHarvUtils::capitalize(strat), ""), pos = 4, cex = text_cex * 1.2)
   
   # summarize percent errors and correlation in estimates
-  errors = KuskoHarvUtils::get_errors(yhat = x$ISMP, yobs = x$PSMP)
+  errors = KuskoHarvUtils::get_errors(yhat = x$ISMP, yobs = x$PSMP, FUN = mean)
   errors = KuskoHarvUtils::percentize(errors$summary[c("MPE", "MAPE", "RHO")])
   
   # include error type labels if a main plot, otherwise just show numbers

--- a/make-figures.R
+++ b/make-figures.R
@@ -224,8 +224,8 @@ dev.off()
 source(file.path(proj_dir, "validation/prepare-calendar-data.R"))
 
 # load opener information and harvest estimates: reload to get all openers (including the 3 unmonitored)
-data(meta, package = "KuskoHarvData")
-data(harvest_estimate_master, package = "KuskoHarvData")
+data(openers_all, package = "KuskoHarvData")
+data(harv_est_all, package = "KuskoHarvData")
 
 # set the colors
 cols = c("chinook" = "black", "chum" = "royalblue", "sockeye" = "tomato")
@@ -241,7 +241,7 @@ calendar_plot = function(y, legend = FALSE, xaxis = TRUE) {
   if (any(duplicated(dat$date))) dat = dat[!duplicated(dat$date),]
   
   # get in-season harvest estimates by opener for this year
-  ests = subset(harvest_estimate_master, year(date) == y & stratum == "total" & quantity == "mean" & species != "total")
+  ests = subset(harv_est_all, year(date) == y & stratum == "total" & quantity == "mean" & species != "total")
   ests = dcast(ests, date ~ species, value.var = "estimate")
   ests[is.na(ests)] = 0
   
@@ -260,7 +260,7 @@ calendar_plot = function(y, legend = FALSE, xaxis = TRUE) {
     lines(p_chum ~ date, col = cols["chum"], lwd = 2)
     
     # add lines at the dates of the openers
-    abline(v = date(meta$start[year(meta$start) == y]), col = "grey50", lty = 2)
+    abline(v = date(openers_all$start[year(openers_all$start) == y]), col = "grey50", lty = 2)
     
     # get user coordinates of plotting region
     usr = par("usr"); xdiff = diff(usr[1:2]); ydiff = diff(usr[3:4])
@@ -308,7 +308,7 @@ mtext(side = 2, outer = TRUE, line = 0.5, "Cumulative Harvest Proportion")
 dev.off()
 
 # remove these versions of meta and harvest_estimate_master
-rm(meta); rm(harvest_estimate_master)
+rm(openers_all); rm(harv_est_all)
 
 ##### MAKE FIGURE: p-covered.png #####
 

--- a/make-in-text-summaries.R
+++ b/make-in-text-summaries.R
@@ -175,7 +175,7 @@ errors = lapply(KuskoHarvUtils::capitalize(spp), function(s) {
   psmp = sub$value[sub$prgm == "PSMP"]
   
   # summarize the errors
-  errors = KuskoHarvUtils::get_errors(yhat = ismp, yobs = psmp)
+  errors = KuskoHarvUtils::get_errors(yhat = ismp, yobs = psmp, FUN = mean)
   names(errors$error) = sort(unique(sub$year))
   names(errors$p_error) = sort(unique(sub$year))
   errors
@@ -191,7 +191,7 @@ chinook_MPE = sapply(c("A", "B", "C", "D1"), function(s) {
   sub = subset(values, spp == "Chinook" & stratum == s & stat == "est")
   ismp = sub$value[sub$prgm == "ISMP"]
   psmp = sub$value[sub$prgm == "PSMP"]
-  errors = KuskoHarvUtils::get_errors(yhat = ismp, yobs = psmp)
+  errors = KuskoHarvUtils::get_errors(yhat = ismp, yobs = psmp, FUN = mean)
   unname(KuskoHarvUtils::percentize(errors$summary["MPE"]))
 })
 


### PR DESCRIPTION
This PR merges several small changes that fix minor bugs related to my ongoing development of the 'KuskoHarv*' family of packages. The two bugs were:

1. Several instances of loading data sets from 'KuskoHarvData' referenced data set names used prior to KuskoHarvData v2023.4, which created errors (`...object not found...`).
2. Several instances of MPE and MAPE were calculated using median error, rather than mean. Mean was used in the original submission, and the change was not intended for the revised submission. The default behavior of `KuskoHarvUtils::get_errors()` was updated in v0.1.3 and I forgot it would need updating here.

Regrettably, the second resulted in several numbers being incorrectly printed in the revised manuscript submitted to the journal on 2024-08-02. Fortunately, the error was isolated to several sentences, and the corresponding figure (Figure 3) was not affected.

### **Erroneous Text in _Revised Submission_**:

![image](https://github.com/user-attachments/assets/33e1f58e-15f6-4c83-b207-67e10883355a)

### **Correct Text - Same as _Original Submission L398-407_**:

![image](https://github.com/user-attachments/assets/3b7e6c17-48ae-45fa-982e-250c938d7239)

### **Figure 3 in _Original Submission_** 

![image](https://github.com/user-attachments/assets/e18bbe62-45db-49eb-b761-cbd316b8e238)

### **Identical Figure 3 in _Revised Submission_**

![image](https://github.com/user-attachments/assets/516add78-9b78-4041-9edd-c45e850cf2db)

I plan to notify the journal and will follow their advice on how to address this for the current draft in review. Fixing this now ensures it will not carry through to publication.
